### PR TITLE
Fix comment syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - 💞️ I’m looking to collaborate on ...
 - 📫 How to reach me ...
 
-<!---
+<!--
 Fan8322975/Fan8322975 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
---->
+-->


### PR DESCRIPTION
## Summary
- fix README comment syntax to properly hide instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841546afaac832ab0db859d213e3ce5